### PR TITLE
Expose GCP secrets key IDs

### DIFF
--- a/secrets/gcp/path_config.go
+++ b/secrets/gcp/path_config.go
@@ -72,15 +72,25 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, data
 		return nil, nil
 	}
 
-	configData := map[string]interface{}{
-		"ttl":                   int64(cfg.TTL / time.Second),
-		"max_ttl":               int64(cfg.MaxTTL / time.Second),
-		"service_account_email": cfg.ServiceAccountEmail,
+	resp := &logical.Response{
+		Data: map[string]interface{}{
+			"ttl":                   int64(cfg.TTL / time.Second),
+			"max_ttl":               int64(cfg.MaxTTL / time.Second),
+			"service_account_email": cfg.ServiceAccountEmail,
+			"private_key_id":        "",
+		},
 	}
 
-	return &logical.Response{
-		Data: configData,
-	}, nil
+	creds, err := gcputil.Credentials(cfg.CredentialsRaw)
+	if err != nil {
+		resp.Warnings = []string{
+			fmt.Sprintf("Failed to parse key private key ID: %v", err),
+		}
+	} else {
+		resp.Data["private_key_id"] = creds.PrivateKeyId
+	}
+
+	return resp, nil
 }
 
 func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {

--- a/secrets/gcp/path_config_test.go
+++ b/secrets/gcp/path_config_test.go
@@ -32,6 +32,7 @@ func TestConfig(t *testing.T) {
 		"ttl":                   int64(0),
 		"max_ttl":               int64(0),
 		"service_account_email": "",
+		"private_key_id":        "privateKey123",
 	}
 
 	testConfigRead(t, b, reqStorage, expected)

--- a/secrets/gcp/path_role_set.go
+++ b/secrets/gcp/path_role_set.go
@@ -6,6 +6,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"path"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao-plugins/secrets/gcp/util"
@@ -179,6 +180,7 @@ func (b *backend) pathRoleSetRead(ctx context.Context, req *logical.Request, d *
 
 	if rs.TokenGen != nil && rs.SecretType == SecretTypeAccessToken {
 		data["token_scopes"] = rs.TokenGen.Scopes
+		data["private_key_id"] = path.Base(rs.TokenGen.KeyName)
 	}
 
 	return &logical.Response{
@@ -419,7 +421,12 @@ func (b *backend) pathRoleSetRotateKey(ctx context.Context, req *logical.Request
 	if warn != "" {
 		return &logical.Response{Warnings: []string{warn}}, nil
 	}
-	return nil, nil
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"private_key_id": path.Base(rs.TokenGen.KeyName),
+		},
+	}, nil
 }
 
 func getRoleSet(name string, ctx context.Context, s logical.Storage) (*RoleSet, error) {

--- a/secrets/gcp/path_static_account.go
+++ b/secrets/gcp/path_static_account.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/openbao/openbao/sdk/v2/framework"
@@ -131,6 +132,7 @@ func (b *backend) pathStaticAccountRead(ctx context.Context, req *logical.Reques
 	}
 	if acct.TokenGen != nil && acct.SecretType == SecretTypeAccessToken {
 		data["token_scopes"] = acct.TokenGen.Scopes
+		data["private_key_id"] = path.Base(acct.TokenGen.KeyName)
 	}
 
 	return &logical.Response{

--- a/secrets/gcp/path_static_account_rotate_key.go
+++ b/secrets/gcp/path_static_account_rotate_key.go
@@ -6,6 +6,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"path"
 
 	"github.com/openbao/openbao/sdk/v2/framework"
 	"github.com/openbao/openbao/sdk/v2/logical"
@@ -108,7 +109,12 @@ func (b *backend) pathStaticAccountRotateKey(ctx context.Context, req *logical.R
 		}
 		b.tryDeleteWALs(ctx, req.Storage, oldWalId)
 	}
-	return nil, nil
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"private_key_id": path.Base(acct.TokenGen.KeyName),
+		},
+	}, nil
 }
 
 const pathStaticAccountRotateKeyHelpSyn = `Rotate the key used to generate access tokens for a static account`


### PR DESCRIPTION
Attempt to address [Expose GCP secrets key IDs #13](https://github.com/openbao/openbao-plugins/issues/13)

- Key IDs are consistently displayed when rotated
- Key IDs can be read for mount, rolesets and static accounts

Mount operations
```
# Reading mount configuration.
bao read gcp/config

Key                      Value
---                      -----
max_ttl                  4h
private_key_id           b6a47b005b4c718322c891608873a4aa330562dc
service_account_email    bao@my-project.iam.gserviceaccount.com
ttl                      1h

# Rotating root credentials (existing behaviour)
bao write -f gcp/config/rotate-root

Key               Value
---               -----
private_key_id    2d30a5de98138d3e99af949e2af140482a1552db
```

Static account operations
```
# Reading static account.
bao read gcp/static-account/static-01

Key                        Value
---                        -----
private_key_id             9459858d15af346d2c00533700ba32e8d1fc1664
secret_type                access_token
service_account_email      static-01@my-project.iam.gserviceaccount.com
service_account_project    my-project
token_scopes               [https://www.googleapis.com/auth/cloud-platform]

# Rotating static account credentials.
bao write -f gcp/static-account/static-01/rotate-key

Key               Value
---               -----
private_key_id    342501dcc414f3928dd78e3cdcbf711f06009bbf
```

Roleset operations
```
# Reading roleset.
bao read gcp/roleset/roleset-01

Key                      Value
---                      -----
bindings                 map[//cloudresourcemanager.googleapis.com/projects/my-project:[roles/viewer]]
private_key_id           c0b7506dbe911ea270139a0a384e621ff86a834a
project                  my-project
secret_type              access_token
service_account_email    baoroleset-01-1751861901@my-project.iam.gserviceaccount.com
token_scopes             [https://www.googleapis.com/auth/cloud-platform]

# Rotating roleset credentials.
bao write -f gcp/roleset/roleset-01/rotate-key

Key               Value
---               -----
private_key_id    b1f9962977a2e9539afa2e1623086e62e5f5315c
```