### PR TITLE
add option to republish existing release OCI images

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -11,6 +11,11 @@ on:
         description: Version to publish
         required: true
         type: string
+      republish:
+        description: Republish existing release (download assets instead of building)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -31,6 +36,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: matrix
+    if: ${{ !inputs.republish }}
     strategy:
       matrix:
         target: ${{ fromJSON(needs.matrix.outputs.targets) }}
@@ -49,9 +55,39 @@ jobs:
         with:
           name: plugin-${{ matrix.target }}
           path: bin/*
+  download-release:
+    runs-on: ubuntu-latest
+    needs: matrix
+    if: ${{ inputs.republish }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download release assets
+        run: |
+          mkdir -p bin tmp
+          # Download the compressed binary archives
+          gh release download ${{ inputs.plugin }}-${{ inputs.version }} --pattern "*.tar.gz" --dir tmp
+          gh release download ${{ inputs.plugin }}-${{ inputs.version }} --pattern "*.zip" --dir tmp
+
+          # Extract binaries from archives
+          find tmp -name '*.tar.gz' -exec tar xfz \{\} -C bin --wildcards "openbao-plugin-*" \;
+          find tmp -name '*.zip' -exec unzip -j \{\} "openbao-plugin-*" -d bin \;
+
+          # Rename ARM binaries from older releases
+          for file in bin/*_v8.0; do mv "$file" "${file%_v8.0}_v8"; done
+
+          ls -la bin/
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-republish
+          path: bin/*
   push-image:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, download-release]
+    if: always() && (needs.build.result == 'success' || needs.download-release.result == 'success')
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This will allow us to reupload the OCI image for an existing release in case there are issues.