### PR TITLE
auth-aws: fix nil pointer access on empty client config

### DIFF
--- a/auth/aws/path_login.go
+++ b/auth/aws/path_login.go
@@ -319,23 +319,23 @@ func (b *backend) pathLoginIamGetRoleNameCallerIdAndEntity(ctx context.Context, 
 		if config.MaxRetries >= 0 {
 			maxRetries = config.MaxRetries
 		}
-	}
 
-	// Extract and use a regional STS endpoint
-	// based on the region set in the Authorization header.
-	if config.UseSTSRegionFromClient {
-		clientSpecifiedRegion, err := awsRegionFromHeader(headers.Get("Authorization"))
-		if err != nil {
-			return "", nil, nil, logical.ErrorResponse("region missing from Authorization header"), nil
+		// Extract and use a regional STS endpoint
+		// based on the region set in the Authorization header.
+		if config.UseSTSRegionFromClient {
+			clientSpecifiedRegion, err := awsRegionFromHeader(headers.Get("Authorization"))
+			if err != nil {
+				return "", nil, nil, logical.ErrorResponse("region missing from Authorization header"), nil
+			}
+
+			url, err := stsRegionalEndpoint(clientSpecifiedRegion)
+			if err != nil {
+				return "", nil, nil, logical.ErrorResponse(err.Error()), nil
+			}
+
+			b.Logger().Debug("use_sts_region_from_client set; using region specified from header", "region", clientSpecifiedRegion)
+			endpoint = url
 		}
-
-		url, err := stsRegionalEndpoint(clientSpecifiedRegion)
-		if err != nil {
-			return "", nil, nil, logical.ErrorResponse(err.Error()), nil
-		}
-
-		b.Logger().Debug("use_sts_region_from_client set; using region specified from header", "region", clientSpecifiedRegion)
-		endpoint = url
 	}
 
 	b.Logger().Debug("submitting caller identity request", "endpoint", endpoint)


### PR DESCRIPTION
Ensure the configured AWS client is not nil before trying to access any
of it's fields.

Signed-off-by: Jan Martens <jan@martens.eu.org>