### PR TITLE
consul plugin: drop deprecated features

### DIFF
--- a/secrets/consul/CHANGELOG.md
+++ b/secrets/consul/CHANGELOG.md
@@ -23,8 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - replace "Vault" with "OpenBao" in docs
 - use OpenBao go packages
 - refactor "main.go" to match other plugins
+- oldest supported Consul versions is now 1.4
 
 ### Other
 
 - code import
 - vendor new dependencies
+
+### Removed
+
+- deprecated features inherited from forking

--- a/secrets/consul/README.md
+++ b/secrets/consul/README.md
@@ -5,6 +5,7 @@ This is a standalone backend plugin for use with
 ACL tokens dynamically based on pre-existing Consul ACL policies.
 
 ## Quick Links
+
 - [Docs](docs/readme.md)
 - [API docs](docs/api/readme.md)
 - Main Project Github: https://www.github.com/openbao/openbao

--- a/secrets/consul/docs/api/readme.md
+++ b/secrets/consul/docs/api/readme.md
@@ -4,8 +4,8 @@ This is the API documentation for the OpenBao Consul secrets engine. For general
 information about the usage and operation of the Consul secrets engine, please
 see the [OpenBao Consul documentation](../readme.md).
 
-This documentation assumes the Consul secrets engine is enabled at the `/consul`
-path in OpenBao. Since it is possible to enable secrets engines at any location,
+This documentation assumes the Consul secrets engine is mounted at the `/consul`
+path in OpenBao. Since it is possible to mount secrets engines at any location,
 please update your API calls accordingly.
 
 ## Configure access
@@ -20,31 +20,33 @@ Consul tokens.
 
 ### Parameters
 
-- `address` `(string: <required>)` – Specifies the address of the Consul
+- `address` `(string: <required>)` – Specifies the address of the Consul
   instance, provided as `"host:port"` like `"127.0.0.1:8500"`.
 
-- `scheme` `(string: "http")` – Specifies the URL scheme to use.
+- `scheme` `(string: "http")` – Specifies the URL scheme to use ("http" or
+  "https").
 
-- `token` `(string: "")` – Specifies the Consul ACL token to use. This
-  must be a management type token. If this is not provided, OpenBao will try to
-  bootstrap the ACL system of the Consul cluster automatically.
+- `token` `(string: "")` – Specifies the Consul ACL token to use. If this is not
+  provided, the plugin will try to bootstrap the ACL system of the Consul
+  cluster automatically.
 
-- `ca_cert` `(string: "")` - CA certificate to use when verifying Consul server certificate,
-  must be x509 PEM encoded.
+- `ca_cert` `(string: "")` - CA certificate to use when verifying Consul server
+  certificate, must be x509 PEM encoded.
 
-- `client_cert` `(string: "")` - Client certificate used for Consul's TLS communication,
-  must be x509 PEM encoded and if this is set you need to also set client_key.
+- `client_cert` `(string: "")` - Client certificate used for Consul's TLS
+  communication, must be x509 PEM encoded and if this is set you need to also
+  set `client_key`.
 
-- `client_key` `(string: "")` - Client key used for Consul's TLS communication,
-  must be x509 PEM encoded and if this is set you need to also set client_cert.
+- `client_key` `(string: "")` - Client key used for Consul's TLS communication, must
+  be x509 PEM encoded and if this is set you need to also set `client_cert`.
 
 ### Sample payload
 
 ```json
 {
-  "address": "127.0.0.1:8500",
+  "address": "consul.example.com:8500",
   "scheme": "https",
-  "token": "adha..."
+  "token": "ffffffff-ffff-ffff-ffff-ffffffffffff"
 }
 ```
 
@@ -58,162 +60,88 @@ $ curl \
     http://127.0.0.1:8200/v1/consul/config/access
 ```
 
+## Read access configuration
+
+This endpoint queries for information about the Consul connection.
+
+| Method | Path                    |
+| :----- | :---------------------- |
+| `GET`  | `/consul/config/access` |
+
+### Sample request
+
+```shell-session
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/consul/config/access
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "address": "consul.example.com:8500",
+    "scheme": "https"
+  }
+}
+```
+
 ## Create/Update role
 
-This endpoint creates or updates the Consul role definition. If the role does
-not exist, it will be created. If the role already exists, it will receive
-updated attributes. At least one of `consul_policies`, `consul_roles`,
-`service_identities`, or `node_identities` is required depending on the
-Consul version.
+This endpoint creates or updates the Consul role definition in OpenBao. If the
+role does not exist, it will be created. If the role already exists, it will
+receive updated attributes. At least one of `consul_roles`, `consul_policies`,
+`node_identities`, or `service_identities` is required.
 
 | Method | Path                  |
 | :----- | :-------------------- |
 | `POST` | `/consul/roles/:name` |
 
-### Parameters for consul versions 1.11 and above
+### Parameters
 
-- `partition` `(string: "")` - Specifies the Consul admin partition in which the
-  token is generated. The partition must exist, and the Consul policies or roles
-  assigned to the OpenBao role must also exist inside the given partition. If
-  not provided, the partition `default` is used.
+- `name` `(string: <required>)` – Specifies the name of the role to
+  create/update. This is part of the request URL.
 
-To create a client token within a particular Consul admin partition:
+- `consul_policies` `(array: [])` – The list of Consul policies to assign to the
+  generated token.
 
-```json
-{
-  "partition": "admin1"
-}
-```
+- `consul_roles` `(array: [])` – The list of Consul roles to assign to the
+  generated token.
 
-### Parameters for consul versions 1.8 and above
+- `service_identities` `(array: [])` – The list of service identities to assign
+  to the generated token.
 
-- `node_identities` `(list: <node identity or identities>)` - The list of node
-  identities to assign to the generated token. This may be a comma-separated
-  list to attach multiple node identities to a token.
+- `node_identities` `(array: [])` - The list of node identities to assign to the
+  generated token. Available in Consul 1.8 or above.
 
-To create a client token with node identities attached:
+- `consul_namespace` `(string: "default")` - Specifies the Consul namespace in
+  which the token is generated. Available in Consul 1.7 and above. Requires
+  Consul Enterprise.
 
-```json
-{
-  "node_identities": [
-      "client-1:dc1",
-      "client-2:dc1"
-    ]
-}
-```
-
-### Parameters for consul versions 1.7 and above
-
-- `consul_namespace` `(string: "")` - Specifies the Consul namespace in which
-  the token is generated. The namespace must exist, and the Consul policies or
-  roles assigned to the OpenBao role must also exist inside the given Consul
-  namespace. If not provided, the namespace `default` is used.
-
-To create a client token within a particular Consul namespace:
-
-```json
-{
-  "consul_namespace": "ns1"
-}
-```
-
-### Parameters for consul version 1.5 and above
-
-- `service_identities` `(list: <service identity or identities>)` - The list of
-  service identities to assign to the generated token. This may be a
-  comma-separated list to attach multiple service identities to a token.
-
-- `consul_roles` `(list: <role or roles>)` – The list of Consul roles to attach
-  to the token generated by OpenBao.
-
-
-### Sample payload
-
-To create a client token with roles defined in Consul:
-
-```json
-{
-  "consul_roles": "role-a,role-b"
-}
-```
-
-To create a client token with service identities attached:
-
-```json
-{
-  "service_identities": [
-      "myservice-1:dc1,dc2",
-      "myservice-2:dc1"
-    ]
-}
-```
-
-### Parameters for consul versions 1.4 and above
-
-- `name` `(string: <required>)` – Specifies the name of an existing role against
-  which to create this Consul credential. This is part of the request URL.
-
-- `token_type` deprecated `(string: "client")` - Specifies the type of token to
-  create when using this role. Valid values are `"client"` or `"management"`. If
-  a `"management"` token, the `policy` parameter is not required. Defaults to
-  `"client`". Deprecated from Consul as of 1.4 and removed as of Consul 1.11.
-
-- `policy` deprecated `(string: "")` – Specifies the base64-encoded ACL policy.
-  This is required unless the `token_type` is `"management"`. Deprecated from
-  Consul as of 1.4 and removed as of Consul 1.11.
-
-- `policies` deprecated `(list: <policy or policies>)` - Same as `consul_policies`.
-  Deprecated in favor of using `consul_policies`.
-
-- `consul_policies` `(list: <policy or policies>)` – The list of Consul policies
-  to assign to the generated token. This field is required if using using Consul
-  1.4.
+- `partition` `(string: "default")` - Specifies the Consul admin partition in
+  which the token is generated. Available in Consul 1.11 and above. Requires
+  Consul Enterprise.
 
 - `local` `(bool: false)` - Indicates that the token should not be replicated
-  globally and instead be local to the current datacenter. Only available in Consul
-  1.4 and greater.
+  globally and instead be local to the current datacenter.
 
-- `ttl` `(duration: "")` – Specifies the TTL for this role. If not
-  provided, the default OpenBao TTL is used.
-  
-- `max_ttl` `(duration: "")` – Specifies the max TTL for this role. If not
-  provided, the default OpenBao Max TTL is used.
+- `ttl` `(duration: 1h)` - Specifies the TTL of tokens generated for this role.
+  If not provided, the default OpenBao TTL is used.
 
-### Sample payload
-
-To create a client token with policies defined in Consul:
-
-```json
-{
-  "consul_policies": "policy-1,policy-2"
-}
-```
-
-### Parameters for consul version below 1.4
-
-- `lease` deprecated `(duration: "")` – Specifies the lease for this role. If
-  not provided, the default OpenBao lease is used.
-
-- `policy` deprecated `(string: <policy>)` – Specifies the base64-encoded ACL
-  policy. The ACL format can be found in the [Consul ACL
-  documentation](/consul/docs/security/acl/acl-legacy). This is required unless
-  the `token_type` is `"management"`.
+- `max_ttl` `(duration: 24h)` - Specifies the max TTL of tokens generated for
+  this role. If not provided, the default OpenBao max TTL is used.
 
 ### Sample payload
 
-To create a client token with a base64-encoded policy:
+To create a client token with policies "policy1" and "policy2" defined in
+Consul:
 
 ```json
 {
-  "policy": "a2V5ICIi...=="
-}
-```
-
-To create management tokens:
-
-```json
-{
-  "token_type": "management"
+  "consul_policies": "policy1,policy2",
+  "ttl": "10m",
+  "max_ttl": "1h"
 }
 ```
 
@@ -254,9 +182,12 @@ $ curl \
 ```json
 {
   "data": {
-    "policy": "abd2...==",
-    "lease": "1h0m0s",
-    "token_type": "client"
+    "consul_namespace": "",
+    "consul_policies": ["policy1", "policy2"],
+    "local": false,
+    "max_ttl": 3600,
+    "partition": "",
+    "ttl": 600
   }
 }
 ```
@@ -265,9 +196,10 @@ $ curl \
 
 This endpoint lists all existing roles in the secrets engine.
 
-| Method | Path            |
-| :----- | :-------------- |
-| `LIST` | `/consul/roles` |
+| Method | Path                      |
+| :----- | :------------------------ |
+| `LIST` | `/consul/roles`           |
+| `GET`  | `/consul/roles?list=true` |
 
 ### Sample request
 
@@ -299,7 +231,7 @@ not exist, this endpoint will still return a successful response.
 
 ### Parameters
 
-- `name` `(string: <required>)` – Specifies the name of the role to delete. This
+- `name` `(string: <required>)` - Specifies the name of the role to delete. This
   is part of the request URL.
 
 ### Sample request
@@ -322,7 +254,7 @@ definition.
 
 ### Parameters
 
-- `name` `(string: <required>)` – Specifies the name of an existing role against
+- `name` `(string: <required>)` - Specifies the name of an existing role against
   which to create this Consul credential. This is part of the request URL.
 
 ### Sample request
@@ -338,7 +270,11 @@ $ curl \
 ```json
 {
   "data": {
-    "token": "973a31ea-1ec4-c2de-0f63-623f477c2510"
+    "accessor": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    "consul_namespace": "",
+    "local": false,
+    "partition": "",
+    "token": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
   }
 }
 ```

--- a/secrets/consul/path_config.go
+++ b/secrets/consul/path_config.go
@@ -108,7 +108,7 @@ func (b *backend) pathConfigAccessRead(ctx context.Context, req *logical.Request
 	}
 
 	return &logical.Response{
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"address": conf.Address,
 			"scheme":  conf.Scheme,
 		},


### PR DESCRIPTION
Removed all the deprecated features from the consul plugin. Some (like `lease`) were just renames, others are features only supported by ancient consul versions (inline base64 encoded `policy`). 

This is also reflected in the documentation, which a also restructured a bit, now that fewer different modes of operation.