### PR TITLE
feat(aws): support sts_region for STS API calls

### DIFF
--- a/secrets/aws/client.go
+++ b/secrets/aws/client.go
@@ -44,6 +44,10 @@ func getRootConfig(ctx context.Context, s logical.Storage, clientType string, lo
 		case clientType == "sts" && config.STSEndpoint != "":
 			endpoint = *aws.String(config.STSEndpoint)
 		}
+
+		if clientType == "sts" && config.STSRegion != "" {
+			credsConfig.Region = config.STSRegion
+		}
 	}
 
 	if credsConfig.Region == "" {

--- a/secrets/aws/path_config_root.go
+++ b/secrets/aws/path_config_root.go
@@ -45,6 +45,10 @@ func pathConfigRoot(b *backend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Endpoint to custom STS server URL",
 			},
+			"sts_region": {
+				Type:        framework.TypeString,
+				Description: "Region for STS API calls",
+			},
 			"max_retries": {
 				Type:        framework.TypeInt,
 				Default:     aws.UseServiceDefaultRetries,
@@ -100,6 +104,7 @@ func (b *backend) pathConfigRootRead(ctx context.Context, req *logical.Request, 
 		"region":            config.Region,
 		"iam_endpoint":      config.IAMEndpoint,
 		"sts_endpoint":      config.STSEndpoint,
+		"sts_region":        config.STSRegion,
 		"max_retries":       config.MaxRetries,
 		"username_template": config.UsernameTemplate,
 	}
@@ -112,6 +117,7 @@ func (b *backend) pathConfigRootWrite(ctx context.Context, req *logical.Request,
 	region := data.Get("region").(string)
 	iamendpoint := data.Get("iam_endpoint").(string)
 	stsendpoint := data.Get("sts_endpoint").(string)
+	stsregion := data.Get("sts_region").(string)
 	maxretries := data.Get("max_retries").(int)
 	usernameTemplate := data.Get("username_template").(string)
 	if usernameTemplate == "" {
@@ -126,6 +132,7 @@ func (b *backend) pathConfigRootWrite(ctx context.Context, req *logical.Request,
 		SecretKey:        data.Get("secret_key").(string),
 		IAMEndpoint:      iamendpoint,
 		STSEndpoint:      stsendpoint,
+		STSRegion:        stsregion,
 		Region:           region,
 		MaxRetries:       maxretries,
 		UsernameTemplate: usernameTemplate,
@@ -151,6 +158,7 @@ type rootConfig struct {
 	SecretKey        string `json:"secret_key"`
 	IAMEndpoint      string `json:"iam_endpoint"`
 	STSEndpoint      string `json:"sts_endpoint"`
+	STSRegion        string `json:"sts_region"`
 	Region           string `json:"region"`
 	MaxRetries       int    `json:"max_retries"`
 	UsernameTemplate string `json:"username_template"`

--- a/secrets/aws/path_config_root_test.go
+++ b/secrets/aws/path_config_root_test.go
@@ -26,6 +26,7 @@ func TestBackend_PathConfigRoot(t *testing.T) {
 		"region":            "us-west-2",
 		"iam_endpoint":      "https://iam.amazonaws.com",
 		"sts_endpoint":      "https://sts.us-west-2.amazonaws.com",
+		"sts_region":        "us-west-2",
 		"max_retries":       10,
 		"username_template": defaultUserNameTemplate,
 	}


### PR DESCRIPTION
**Summary:**
Add support for configuring a distinct STS region via `sts_region`.

**What / Why:**

* Some environments require STS API calls to target a different region than IAM or other AWS services.
* This update allows operators to set `sts_region` so `AssumeRole` and `GetFederationToken` requests use that region instead of the default.

**Changes:**

* **path_config_root.go:** Add support for reading and persisting `sts_region` in the `config/root` configuration.
* **client.go:** When `clientType == "sts"` and `sts_region` is defined, use it for AWS config `Region`. Otherwise, fall back to `region`, then `AWS_REGION`, `AWS_DEFAULT_REGION`, and finally `us-east-1`.

Closes #46 
