### PR TITLE
Add the @openbao/openbao-plugins-committers team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,10 @@
-* @openbao/openbao-org-maintainers
+# Most changes can be approved by Org-Level Maintainers and Plugins Comitters
+* @openbao/openbao-org-maintainers @openbao/openbao-plugins-committers
 
-secrets/consul/ @openbao/openbao-org-maintainers @openbao/plugins-secrets-consul-committers 
+# Changes to LICENSE and CODEOWNER itself is more restricted
+CODEOWNERS @openbao/openbao-org-maintainers
+LICENSE    @openbao/openbao-org-maintainers
+
+# Changes to the consul plugin can additionally be approved by the Consol Plugin Comitters
+secrets/consul/ @openbao/openbao-org-maintainers @openbao/openbao-plugins-committers @openbao/plugins-secrets-consul-committers
+


### PR DESCRIPTION
I guess giving access to everything except `LICENSE` and `CODEOWNERS` should be fine.

~~GitHub currently tells me:~~

> ~~Unknown owner on line 2: make sure the team @openbao/openbao-plugins-committers exists, is publicly visible, and has write access to the repository~~

~~I triple checked the name, it's correct. I is also [visible](https://github.com/orgs/openbao/teams?query=openbao-plugins-committers+visibility%3Avisible), so I guess write access to the repo is missing, but I can't change (or even see) this. This should be fixed before merging this PR, so I'm making this as a Draft.~~