### PR TITLE
auth/aws: flush cached clients on STS config change

### DIFF
--- a/auth/aws/backend.go
+++ b/auth/aws/backend.go
@@ -272,7 +272,7 @@ func (b *backend) cleanup(ctx context.Context) {
 
 func (b *backend) invalidate(ctx context.Context, key string) {
 	switch {
-	case key == "config/client":
+	case key == "config/client", strings.HasPrefix(key, "config/sts/"):
 		b.configMutex.Lock()
 		defer b.configMutex.Unlock()
 		b.flushCachedEC2Clients()

--- a/auth/aws/path_config_sts.go
+++ b/auth/aws/path_config_sts.go
@@ -235,6 +235,10 @@ func (b *backend) pathConfigStsCreateUpdate(ctx context.Context, req *logical.Re
 		return nil, err
 	}
 
+	// flush cached clients
+	b.flushCachedEC2Clients()
+	b.flushCachedIAMClients()
+
 	return nil, nil
 }
 
@@ -247,6 +251,10 @@ func (b *backend) pathConfigStsDelete(ctx context.Context, req *logical.Request,
 	if accountID == "" {
 		return logical.ErrorResponse("missing account id"), nil
 	}
+
+	// flush cached clients
+	b.flushCachedEC2Clients()
+	b.flushCachedIAMClients()
 
 	return nil, req.Storage.Delete(ctx, "config/sts/"+accountID)
 }


### PR DESCRIPTION
Changing the STS config did not flush the cached AWS clients, leading to
stale credentials being used for authentication until the client config
changed or the OpenBao server was restarted

Signed-off-by: Jan Martens <jan@martens.eu.org>