### PR TITLE
Add Typesense database plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Prebuilt binaries for these plugins are available in the [Releases](https://gith
 
 ### Database Plugins
 
-_None available at this time._
+- **Typesense** - Generate Typesense API keys with granular permissions.
 
 ### Secrets Plugins
 

--- a/database/typesense/README.md
+++ b/database/typesense/README.md
@@ -1,0 +1,24 @@
+# Typesense Database Plugin
+
+This is the official database plugin for integrating OpenBao with [Typesense](https://typesense.org/).
+
+## Building
+
+To build the plugin from source, run the following command from the root of the `openbao-plugins` repository:
+
+```bash
+make database-typesense
+# Or, for a clean build:
+make clean database-typesense
+```
+
+The compiled binary will be placed in the `bin/` directory, for example: `bin/openbao-plugin-database-typesense_linux_amd64_v1`.
+
+## Testing
+
+To run the integration tests for this plugin, you will need Docker running on your system, as the tests spin up a live Typesense container via `ory/dockertest/v3`.
+
+```bash
+cd database/typesense
+go test -v ./...
+```

--- a/database/typesense/cmd/main.go
+++ b/database/typesense/cmd/main.go
@@ -4,18 +4,11 @@
 package main
 
 import (
-	"os"
-
 	"github.com/openbao/openbao-plugins/database/typesense"
-	"github.com/openbao/openbao/api/v2"
 	dbplugin "github.com/openbao/openbao/sdk/v2/database/dbplugin/v5"
 )
 
 func main() {
-	apiClientMeta := &api.PluginAPIClientMeta{}
-	flags := apiClientMeta.FlagSet()
-	flags.Parse(os.Args[1:])
-
-	// ServeMultiplex directly takes the factory function in the v5 interface
 	dbplugin.ServeMultiplex(typesense.New)
 }
+

--- a/database/typesense/cmd/main.go
+++ b/database/typesense/cmd/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/openbao/openbao-plugins/database/typesense"
+	"github.com/openbao/openbao/api/v2"
+	dbplugin "github.com/openbao/openbao/sdk/v2/database/dbplugin/v5"
+)
+
+func main() {
+	apiClientMeta := &api.PluginAPIClientMeta{}
+	flags := apiClientMeta.FlagSet()
+	flags.Parse(os.Args[1:])
+
+	if err := Run(); err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+}
+
+func Run() error {
+	// ServeMultiplex directly takes the factory function in the v5 interface
+	dbplugin.ServeMultiplex(typesense.New)
+	return nil
+}

--- a/database/typesense/cmd/main.go
+++ b/database/typesense/cmd/main.go
@@ -1,7 +1,9 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/openbao/openbao-plugins/database/typesense"
@@ -14,14 +16,6 @@ func main() {
 	flags := apiClientMeta.FlagSet()
 	flags.Parse(os.Args[1:])
 
-	if err := Run(); err != nil {
-		log.Println(err)
-		os.Exit(1)
-	}
-}
-
-func Run() error {
 	// ServeMultiplex directly takes the factory function in the v5 interface
 	dbplugin.ServeMultiplex(typesense.New)
-	return nil
 }

--- a/database/typesense/typesense.go
+++ b/database/typesense/typesense.go
@@ -26,14 +26,14 @@ func New() (interface{}, error) {
 // typesenseDB implements the dbplugin.Database interface
 type typesenseDB struct {
 	client *typesense.Client
-	apiURL string
+	// apiKey is retained to allow the error sanitizer middleware to redact it from errors/logs
 	apiKey string
 }
 
 // secretValues tells the sanitizer which strings to redact from logs/errors
 func (db *typesenseDB) secretValues() map[string]string {
 	return map[string]string{
-		db.apiKey: "[typesense-admin-key]",
+		db.apiKey: "[typesense-api-key]",
 	}
 }
 
@@ -48,10 +48,9 @@ func (db *typesenseDB) Initialize(ctx context.Context, req dbplugin.InitializeRe
 		return dbplugin.InitializeResponse{}, errors.New("api_key is required")
 	}
 
-	db.apiURL = apiURL
 	db.apiKey = apiKey
 	db.client = typesense.NewClient(
-		typesense.WithServer(db.apiURL),
+		typesense.WithServer(apiURL),
 		typesense.WithAPIKey(db.apiKey),
 		typesense.WithConnectionTimeout(10*time.Second),
 	)

--- a/database/typesense/typesense.go
+++ b/database/typesense/typesense.go
@@ -1,0 +1,197 @@
+package typesense
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	dbplugin "github.com/openbao/openbao/sdk/v2/database/dbplugin/v5"
+)
+
+// New returns a new Typesense database implementation.
+func New() (interface{}, error) {
+	db := &typesenseDB{
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+	// Use the middleware to prevent leaking the Typesense admin API key in error messages
+	return dbplugin.NewDatabaseErrorSanitizerMiddleware(db, db.secretValues), nil
+}
+
+// typesenseDB implements the dbplugin.Database interface
+type typesenseDB struct {
+	client *http.Client
+	apiURL string
+	apiKey string
+}
+
+// secretValues tells the sanitizer which strings to redact from logs/errors
+func (db *typesenseDB) secretValues() map[string]string {
+	return map[string]string{
+		db.apiKey: "[typesense-admin-key]",
+	}
+}
+
+// Initialize configures the plugin and verifies the connection
+func (db *typesenseDB) Initialize(ctx context.Context, req dbplugin.InitializeRequest) (dbplugin.InitializeResponse, error) {
+	apiURL, ok := req.Config["api_url"].(string)
+	if !ok || apiURL == "" {
+		return dbplugin.InitializeResponse{}, errors.New("api_url is required")
+	}
+	apiKey, ok := req.Config["api_key"].(string)
+	if !ok || apiKey == "" {
+		return dbplugin.InitializeResponse{}, errors.New("api_key is required")
+	}
+
+	db.apiURL = apiURL
+	db.apiKey = apiKey
+
+	if req.VerifyConnection {
+		// Ping the Typesense health endpoint
+		httpReq, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/health", db.apiURL), nil)
+		if err != nil {
+			return dbplugin.InitializeResponse{}, err
+		}
+
+		resp, err := db.client.Do(httpReq)
+		if err != nil {
+			return dbplugin.InitializeResponse{}, fmt.Errorf("failed to connect to Typesense: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return dbplugin.InitializeResponse{}, fmt.Errorf("typesense returned non-200 status: %d", resp.StatusCode)
+		}
+	}
+
+	return dbplugin.InitializeResponse{
+		Config: req.Config,
+	}, nil
+}
+
+// NewUser creates a new API key in Typesense
+func (db *typesenseDB) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (dbplugin.NewUserResponse, error) {
+	// 1. Generate the username dynamically using OpenBao's contextual metadata
+	// Example: v-myusername-myrole-1678829283
+	generatedUsername := fmt.Sprintf("v-%s-%s-%d", req.UsernameConfig.DisplayName, req.UsernameConfig.RoleName, time.Now().Unix())
+
+	// 2. Prepare the Typesense Key payload
+	payloadStr := `{"actions": ["*"], "collections": ["*"]}`
+	if len(req.Statements.Commands) > 0 {
+		payloadStr = req.Statements.Commands[0]
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(payloadStr), &payload); err != nil {
+		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to parse creation_statements as JSON: %w", err)
+	}
+
+	// 3. Inject the dynamically generated identity and password
+	payload["description"] = generatedUsername
+	payload["value"] = req.Password
+	if !req.Expiration.IsZero() {
+		payload["expires_at"] = req.Expiration.Unix()
+	}
+
+	payloadBytes, _ := json.Marshal(payload)
+
+	// 4. Send request to Typesense
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/keys", db.apiURL), bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return dbplugin.NewUserResponse{}, err
+	}
+	httpReq.Header.Set("X-TYPESENSE-API-KEY", db.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := db.client.Do(httpReq)
+	if err != nil {
+		return dbplugin.NewUserResponse{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to create Typesense key: %s (status %d)", string(bodyBytes), resp.StatusCode)
+	}
+
+	// 5. Return the generated username back to OpenBao so it can track it
+	return dbplugin.NewUserResponse{
+		Username: generatedUsername,
+	}, nil
+}
+
+// DeleteUser revokes the API key from Typesense
+func (db *typesenseDB) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRequest) (dbplugin.DeleteUserResponse, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/keys", db.apiURL), nil)
+	if err != nil {
+		return dbplugin.DeleteUserResponse{}, err
+	}
+	httpReq.Header.Set("X-TYPESENSE-API-KEY", db.apiKey)
+
+	resp, err := db.client.Do(httpReq)
+	if err != nil {
+		return dbplugin.DeleteUserResponse{}, err
+	}
+	defer resp.Body.Close()
+
+	var keysResponse struct {
+		Keys []struct {
+			ID          int    `json:"id"`
+			Description string `json:"description"`
+		} `json:"keys"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&keysResponse); err != nil {
+		return dbplugin.DeleteUserResponse{}, err
+	}
+
+	var keyIDToDelete int = -1
+	for _, k := range keysResponse.Keys {
+		// OpenBao gives us back the exact username we generated during NewUser
+		if k.Description == req.Username {
+			keyIDToDelete = k.ID
+			break
+		}
+	}
+
+	if keyIDToDelete == -1 {
+		return dbplugin.DeleteUserResponse{}, nil // Key already gone
+	}
+
+	delReq, err := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/keys/%d", db.apiURL, keyIDToDelete), nil)
+	if err != nil {
+		return dbplugin.DeleteUserResponse{}, err
+	}
+	delReq.Header.Set("X-TYPESENSE-API-KEY", db.apiKey)
+
+	delResp, err := db.client.Do(delReq)
+	if err != nil {
+		return dbplugin.DeleteUserResponse{}, err
+	}
+	defer delResp.Body.Close()
+
+	if delResp.StatusCode != http.StatusOK && delResp.StatusCode != http.StatusNotFound {
+		return dbplugin.DeleteUserResponse{}, fmt.Errorf("failed to delete key: status %d", delResp.StatusCode)
+	}
+
+	return dbplugin.DeleteUserResponse{}, nil
+}
+
+// UpdateUser is not supported for Typesense keys.
+func (db *typesenseDB) UpdateUser(ctx context.Context, req dbplugin.UpdateUserRequest) (dbplugin.UpdateUserResponse, error) {
+	return dbplugin.UpdateUserResponse{}, errors.New("update/rotation is not supported for typesense keys")
+}
+
+// Type returns the type of the database.
+func (db *typesenseDB) Type() (string, error) {
+	return "typesense", nil
+}
+
+// Close is a no-op for Typesense.
+func (db *typesenseDB) Close() error {
+	return nil
+}

--- a/database/typesense/typesense.go
+++ b/database/typesense/typesense.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// Copyright (c) 2026 Floatplane Media
+// SPDX-License-Identifier: MPL-2.0
+
 package typesense
 
 import (

--- a/database/typesense/typesense.go
+++ b/database/typesense/typesense.go
@@ -12,9 +12,13 @@ import (
 	"time"
 
 	dbplugin "github.com/openbao/openbao/sdk/v2/database/dbplugin/v5"
+	"github.com/openbao/openbao/sdk/v2/helper/template"
 	"github.com/typesense/typesense-go/typesense"
 	"github.com/typesense/typesense-go/typesense/api"
 )
+
+const defaultUsernameTemplate = `{{ printf "v-%s-%s-%s" (.DisplayName | truncate 20) (.RoleName | truncate 20) (unix_time) }}`
+
 
 // New returns a new Typesense database implementation.
 func New() (interface{}, error) {
@@ -74,8 +78,16 @@ func (db *typesenseDB) Initialize(ctx context.Context, req dbplugin.InitializeRe
 // NewUser creates a new API key in Typesense
 func (db *typesenseDB) NewUser(ctx context.Context, req dbplugin.NewUserRequest) (dbplugin.NewUserResponse, error) {
 	// 1. Generate the username dynamically using OpenBao's contextual metadata
-	// Example: v-myusername-myrole-1678829283
-	generatedUsername := fmt.Sprintf("v-%s-%s-%d", req.UsernameConfig.DisplayName, req.UsernameConfig.RoleName, time.Now().Unix())
+	up, err := template.NewTemplate(template.Template(defaultUsernameTemplate))
+	if err != nil {
+		return dbplugin.NewUserResponse{}, fmt.Errorf("unable to initialize username template: %w", err)
+	}
+
+	generatedUsername, err := up.Generate(req.UsernameConfig)
+	if err != nil {
+		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to generate username: %w", err)
+	}
+
 
 	// 2. Prepare the Typesense Key payload
 	payloadStr := `{"actions": ["*"], "collections": ["*"]}`
@@ -97,7 +109,7 @@ func (db *typesenseDB) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 	}
 
 	// 4. Send request to Typesense
-	_, err := db.client.Keys().Create(ctx, &payload)
+	_, err = db.client.Keys().Create(ctx, &payload)
 	if err != nil {
 		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to create Typesense key: %w", err)
 	}

--- a/database/typesense/typesense.go
+++ b/database/typesense/typesense.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	dbplugin "github.com/openbao/openbao/sdk/v2/database/dbplugin/v5"
@@ -109,29 +111,44 @@ func (db *typesenseDB) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 	}
 
 	// 4. Send request to Typesense
-	_, err = db.client.Keys().Create(ctx, &payload)
+	createdKey, err := db.client.Keys().Create(ctx, &payload)
 	if err != nil {
 		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to create Typesense key: %w", err)
 	}
+	if createdKey == nil || createdKey.Id == nil {
+		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to retrieve created key ID from Typesense")
+	}
 
 	// 5. Return the generated username back to OpenBao so it can track it
+	// Format: <id>-<generatedUsername>
 	return dbplugin.NewUserResponse{
-		Username: generatedUsername,
+		Username: fmt.Sprintf("%d-%s", *createdKey.Id, generatedUsername),
 	}, nil
 }
 
 // DeleteUser revokes the API key from Typesense
 func (db *typesenseDB) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRequest) (dbplugin.DeleteUserResponse, error) {
-	keys, err := db.client.Keys().Retrieve(ctx)
-	if err != nil {
-		return dbplugin.DeleteUserResponse{}, err
+	var keyIDToDelete int64 = -1
+
+	// Try to parse the key ID from the username (format: "<id>-<description>")
+	parts := strings.SplitN(req.Username, "-", 2)
+	if len(parts) == 2 {
+		if id, err := strconv.ParseInt(parts[0], 10, 64); err == nil {
+			keyIDToDelete = id
+		}
 	}
 
-	var keyIDToDelete int64 = -1
-	for _, k := range keys {
-		if k.Description == req.Username && k.Id != nil {
-			keyIDToDelete = *k.Id
-			break
+	if keyIDToDelete == -1 {
+		// Fallback: linear search for the key by description (for legacy leases)
+		keys, err := db.client.Keys().Retrieve(ctx)
+		if err != nil {
+			return dbplugin.DeleteUserResponse{}, err
+		}
+		for _, k := range keys {
+			if k.Description == req.Username && k.Id != nil {
+				keyIDToDelete = *k.Id
+				break
+			}
 		}
 	}
 
@@ -139,8 +156,12 @@ func (db *typesenseDB) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRe
 		return dbplugin.DeleteUserResponse{}, nil // Key already gone
 	}
 
-	_, err = db.client.Key(keyIDToDelete).Delete(ctx)
+	_, err := db.client.Key(keyIDToDelete).Delete(ctx)
 	if err != nil {
+		var httpErr *typesense.HTTPError
+		if errors.As(err, &httpErr) && httpErr.Status == 404 {
+			return dbplugin.DeleteUserResponse{}, nil // Key already gone
+		}
 		return dbplugin.DeleteUserResponse{}, fmt.Errorf("failed to delete key: %w", err)
 	}
 

--- a/database/typesense/typesense.go
+++ b/database/typesense/typesense.go
@@ -5,30 +5,27 @@
 package typesense
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"time"
 
 	dbplugin "github.com/openbao/openbao/sdk/v2/database/dbplugin/v5"
+	"github.com/typesense/typesense-go/typesense"
+	"github.com/typesense/typesense-go/typesense/api"
 )
 
 // New returns a new Typesense database implementation.
 func New() (interface{}, error) {
-	db := &typesenseDB{
-		client: &http.Client{Timeout: 10 * time.Second},
-	}
+	db := &typesenseDB{}
 	// Use the middleware to prevent leaking the Typesense admin API key in error messages
 	return dbplugin.NewDatabaseErrorSanitizerMiddleware(db, db.secretValues), nil
 }
 
 // typesenseDB implements the dbplugin.Database interface
 type typesenseDB struct {
-	client *http.Client
+	client *typesense.Client
 	apiURL string
 	apiKey string
 }
@@ -53,22 +50,20 @@ func (db *typesenseDB) Initialize(ctx context.Context, req dbplugin.InitializeRe
 
 	db.apiURL = apiURL
 	db.apiKey = apiKey
+	db.client = typesense.NewClient(
+		typesense.WithServer(db.apiURL),
+		typesense.WithAPIKey(db.apiKey),
+		typesense.WithConnectionTimeout(10*time.Second),
+	)
 
 	if req.VerifyConnection {
 		// Ping the Typesense health endpoint
-		httpReq, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/health", db.apiURL), nil)
-		if err != nil {
-			return dbplugin.InitializeResponse{}, err
-		}
-
-		resp, err := db.client.Do(httpReq)
+		ok, err := db.client.Health(ctx, 5*time.Second)
 		if err != nil {
 			return dbplugin.InitializeResponse{}, fmt.Errorf("failed to connect to Typesense: %w", err)
 		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return dbplugin.InitializeResponse{}, fmt.Errorf("typesense returned non-200 status: %d", resp.StatusCode)
+		if !ok {
+			return dbplugin.InitializeResponse{}, errors.New("typesense health check returned false")
 		}
 	}
 
@@ -89,37 +84,23 @@ func (db *typesenseDB) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 		payloadStr = req.Statements.Commands[0]
 	}
 
-	var payload map[string]interface{}
+	var payload api.ApiKeySchema
 	if err := json.Unmarshal([]byte(payloadStr), &payload); err != nil {
 		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to parse creation_statements as JSON: %w", err)
 	}
 
 	// 3. Inject the dynamically generated identity and password
-	payload["description"] = generatedUsername
-	payload["value"] = req.Password
+	payload.Description = generatedUsername
+	payload.Value = &req.Password
 	if !req.Expiration.IsZero() {
-		payload["expires_at"] = req.Expiration.Unix()
+		exp := req.Expiration.Unix()
+		payload.ExpiresAt = &exp
 	}
-
-	payloadBytes, _ := json.Marshal(payload)
 
 	// 4. Send request to Typesense
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/keys", db.apiURL), bytes.NewBuffer(payloadBytes))
+	_, err := db.client.Keys().Create(ctx, &payload)
 	if err != nil {
-		return dbplugin.NewUserResponse{}, err
-	}
-	httpReq.Header.Set("X-TYPESENSE-API-KEY", db.apiKey)
-	httpReq.Header.Set("Content-Type", "application/json")
-
-	resp, err := db.client.Do(httpReq)
-	if err != nil {
-		return dbplugin.NewUserResponse{}, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusCreated {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to create Typesense key: %s (status %d)", string(bodyBytes), resp.StatusCode)
+		return dbplugin.NewUserResponse{}, fmt.Errorf("failed to create Typesense key: %w", err)
 	}
 
 	// 5. Return the generated username back to OpenBao so it can track it
@@ -130,34 +111,15 @@ func (db *typesenseDB) NewUser(ctx context.Context, req dbplugin.NewUserRequest)
 
 // DeleteUser revokes the API key from Typesense
 func (db *typesenseDB) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRequest) (dbplugin.DeleteUserResponse, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/keys", db.apiURL), nil)
+	keys, err := db.client.Keys().Retrieve(ctx)
 	if err != nil {
 		return dbplugin.DeleteUserResponse{}, err
 	}
-	httpReq.Header.Set("X-TYPESENSE-API-KEY", db.apiKey)
 
-	resp, err := db.client.Do(httpReq)
-	if err != nil {
-		return dbplugin.DeleteUserResponse{}, err
-	}
-	defer resp.Body.Close()
-
-	var keysResponse struct {
-		Keys []struct {
-			ID          int    `json:"id"`
-			Description string `json:"description"`
-		} `json:"keys"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&keysResponse); err != nil {
-		return dbplugin.DeleteUserResponse{}, err
-	}
-
-	var keyIDToDelete int = -1
-	for _, k := range keysResponse.Keys {
-		// OpenBao gives us back the exact username we generated during NewUser
-		if k.Description == req.Username {
-			keyIDToDelete = k.ID
+	var keyIDToDelete int64 = -1
+	for _, k := range keys {
+		if k.Description == req.Username && k.Id != nil {
+			keyIDToDelete = *k.Id
 			break
 		}
 	}
@@ -166,20 +128,9 @@ func (db *typesenseDB) DeleteUser(ctx context.Context, req dbplugin.DeleteUserRe
 		return dbplugin.DeleteUserResponse{}, nil // Key already gone
 	}
 
-	delReq, err := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/keys/%d", db.apiURL, keyIDToDelete), nil)
+	_, err = db.client.Key(keyIDToDelete).Delete(ctx)
 	if err != nil {
-		return dbplugin.DeleteUserResponse{}, err
-	}
-	delReq.Header.Set("X-TYPESENSE-API-KEY", db.apiKey)
-
-	delResp, err := db.client.Do(delReq)
-	if err != nil {
-		return dbplugin.DeleteUserResponse{}, err
-	}
-	defer delResp.Body.Close()
-
-	if delResp.StatusCode != http.StatusOK && delResp.StatusCode != http.StatusNotFound {
-		return dbplugin.DeleteUserResponse{}, fmt.Errorf("failed to delete key: status %d", delResp.StatusCode)
+		return dbplugin.DeleteUserResponse{}, fmt.Errorf("failed to delete key: %w", err)
 	}
 
 	return dbplugin.DeleteUserResponse{}, nil

--- a/database/typesense/typesense_test.go
+++ b/database/typesense/typesense_test.go
@@ -6,10 +6,8 @@ package typesense
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"testing"
 	"time"
 
@@ -18,6 +16,7 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/typesense/typesense-go/typesense"
 )
 
 type TypesenseTestConfig struct {
@@ -68,35 +67,21 @@ func SetupEphemeralTypesense(t *testing.T) (TypesenseTestConfig, func()) {
 	hostPort := resource.GetPort(internalPort)
 	hostAddress := fmt.Sprintf("http://localhost:%s", hostPort)
 
+	client := typesense.NewClient(
+		typesense.WithServer(hostAddress),
+		typesense.WithAPIKey(adminAPIKey),
+		typesense.WithConnectionTimeout(2*time.Second),
+	)
+
 	pool.MaxWait = 60 * time.Second
 	err = pool.Retry(func() error {
-		healthURL := fmt.Sprintf("%s/health", hostAddress)
-		resp, err := http.Get(healthURL)
+		ok, err := client.Health(context.Background(), 2*time.Second)
 		if err != nil {
-			return fmt.Errorf("Typesense network listener is not yet active: %w", err)
+			return fmt.Errorf("failed to check Typesense health: %w", err)
 		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("Typesense returned non-ready status code: %d", resp.StatusCode)
+		if !ok {
+			return errors.New("typesense health check returned false")
 		}
-
-		bodyBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read Typesense health payload: %w", err)
-		}
-
-		var healthPayload struct {
-			Ok bool `json:"ok"`
-		}
-		if err := json.Unmarshal(bodyBytes, &healthPayload); err != nil {
-			return fmt.Errorf("failed to parse health payload: %w", err)
-		}
-
-		if !healthPayload.Ok {
-			return fmt.Errorf("Typesense health indicator is false")
-		}
-
 		return nil
 	})
 

--- a/database/typesense/typesense_test.go
+++ b/database/typesense/typesense_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// Copyright (c) 2026 Floatplane Media
+// SPDX-License-Identifier: MPL-2.0
+
+package typesense
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	dbplugin "github.com/openbao/openbao/sdk/v2/database/dbplugin/v5"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type TypesenseTestConfig struct {
+	Host    string
+	Port    string
+	APIKey  string
+	Address string
+}
+
+func SetupEphemeralTypesense(t *testing.T) (TypesenseTestConfig, func()) {
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err, "Failed to construct Docker pool")
+
+	err = pool.Client.Ping()
+	require.NoError(t, err, "Failed to establish communication with Docker daemon")
+
+	const (
+		typesenseImage   = "typesense/typesense"
+		typesenseVersion = "29.1"
+		adminAPIKey      = "test-integration-key"
+		internalDataDir  = "/data"
+		internalPort     = "8108/tcp"
+	)
+
+	runOptions := &dockertest.RunOptions{
+		Repository: typesenseImage,
+		Tag:        typesenseVersion,
+		Env: []string{
+			fmt.Sprintf("TYPESENSE_API_KEY=%s", adminAPIKey),
+			fmt.Sprintf("TYPESENSE_DATA_DIR=%s", internalDataDir),
+		},
+		ExposedPorts: []string{internalPort},
+	}
+
+	resource, err := pool.RunWithOptions(runOptions, func(config *docker.HostConfig) {
+		config.Tmpfs = map[string]string{
+			internalDataDir: "",
+		}
+	})
+	require.NoError(t, err, "Failed to dispatch Typesense container")
+
+	cleanup := func() {
+		if err := pool.Purge(resource); err != nil {
+			t.Errorf("Failed to purge Typesense container during cleanup: %v", err)
+		}
+	}
+
+	hostPort := resource.GetPort(internalPort)
+	hostAddress := fmt.Sprintf("http://localhost:%s", hostPort)
+
+	pool.MaxWait = 60 * time.Second
+	err = pool.Retry(func() error {
+		healthURL := fmt.Sprintf("%s/health", hostAddress)
+		resp, err := http.Get(healthURL)
+		if err != nil {
+			return fmt.Errorf("Typesense network listener is not yet active: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("Typesense returned non-ready status code: %d", resp.StatusCode)
+		}
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read Typesense health payload: %w", err)
+		}
+
+		var healthPayload struct {
+			Ok bool `json:"ok"`
+		}
+		if err := json.Unmarshal(bodyBytes, &healthPayload); err != nil {
+			return fmt.Errorf("failed to parse health payload: %w", err)
+		}
+
+		if !healthPayload.Ok {
+			return fmt.Errorf("Typesense health indicator is false")
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		cleanup()
+		t.Fatalf("Typesense container failed to reach operational readiness: %v", err)
+	}
+
+	config := TypesenseTestConfig{
+		Host:    "localhost",
+		Port:    hostPort,
+		APIKey:  adminAPIKey,
+		Address: hostAddress,
+	}
+
+	return config, cleanup
+}
+
+func TestTypesensePlugin_Integration(t *testing.T) {
+	config, cleanup := SetupEphemeralTypesense(t)
+	defer cleanup()
+
+	// 1. Initialize Plugin
+	dbRaw, err := New()
+	require.NoError(t, err)
+
+	db, ok := dbRaw.(dbplugin.Database)
+	require.True(t, ok)
+
+	ctx := context.Background()
+
+	initReq := dbplugin.InitializeRequest{
+		Config: map[string]interface{}{
+			"api_url": config.Address,
+			"api_key": config.APIKey,
+		},
+		VerifyConnection: true,
+	}
+
+	_, err = db.Initialize(ctx, initReq)
+	require.NoError(t, err, "Initialize should succeed with running Typesense instance")
+
+	// 2. Create User
+	newUserReq := dbplugin.NewUserRequest{
+		UsernameConfig: dbplugin.UsernameMetadata{
+			DisplayName: "test",
+			RoleName:    "admin",
+		},
+		Statements: dbplugin.Statements{
+			Commands: []string{`{"actions": ["*"], "collections": ["*"]}`},
+		},
+		Password:   "some-secure-secret-value",
+		Expiration: time.Now().Add(1 * time.Hour),
+	}
+
+	newUserResp, err := db.NewUser(ctx, newUserReq)
+	require.NoError(t, err, "NewUser should successfully create an API key")
+	assert.NotEmpty(t, newUserResp.Username, "NewUser should return the generated username description")
+
+	// 3. Delete User
+	deleteUserReq := dbplugin.DeleteUserRequest{
+		Username: newUserResp.Username,
+	}
+
+	_, err = db.DeleteUser(ctx, deleteUserReq)
+	require.NoError(t, err, "DeleteUser should successfully remove the created API key")
+}

--- a/database/typesense/typesense_test.go
+++ b/database/typesense/typesense_test.go
@@ -141,6 +141,16 @@ func TestTypesensePlugin_Integration(t *testing.T) {
 	require.NoError(t, err, "NewUser should successfully create an API key")
 	assert.NotEmpty(t, newUserResp.Username, "NewUser should return the generated username description")
 
+	// 2b. Verify key validity directly against Typesense
+	userClient := typesense.NewClient(
+		typesense.WithServer(config.Address),
+		typesense.WithAPIKey(newUserReq.Password),
+		typesense.WithConnectionTimeout(2*time.Second),
+	)
+
+	_, err = userClient.Collections().Retrieve(ctx)
+	require.NoError(t, err, "Should be able to retrieve collections using the generated key")
+
 	// 3. Delete User
 	deleteUserReq := dbplugin.DeleteUserRequest{
 		Username: newUserResp.Username,
@@ -148,4 +158,8 @@ func TestTypesensePlugin_Integration(t *testing.T) {
 
 	_, err = db.DeleteUser(ctx, deleteUserReq)
 	require.NoError(t, err, "DeleteUser should successfully remove the created API key")
+
+	// 3b. Verify key invalidity directly against Typesense
+	_, err = userClient.Collections().Retrieve(ctx)
+	require.Error(t, err, "Should fail to retrieve collections after the key is deleted")
 }

--- a/go.mod
+++ b/go.mod
@@ -65,9 +65,11 @@ require (
 	github.com/openbao/openbao v0.0.0-20250828202315-f9407a27fbee
 	github.com/openbao/openbao/api/v2 v2.5.0
 	github.com/openbao/openbao/sdk/v2 v2.4.0
+	github.com/ory/dockertest/v3 v3.12.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.11.1
+	github.com/typesense/typesense-go v1.1.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/oauth2 v0.34.0
@@ -84,6 +86,7 @@ require (
 	cloud.google.com/go/iam v1.5.2 // indirect
 	cloud.google.com/go/longrunning v0.6.7 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
+	dario.cat/mergo v1.0.1 // indirect
 	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
@@ -108,8 +111,10 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.12 // indirect
+	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
@@ -137,6 +142,7 @@ require (
 	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible // indirect
 	github.com/circonus-labs/circonusllhist v0.1.3 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
+	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
@@ -145,6 +151,7 @@ require (
 	github.com/digitalocean/godo v1.7.5 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/cli v28.3.3+incompatible // indirect
 	github.com/docker/docker v28.3.3+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -174,6 +181,7 @@ require (
 	github.com/google/go-metrics-stackdriver v0.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
@@ -240,10 +248,12 @@ require (
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 // indirect
+	github.com/oapi-codegen/runtime v1.1.1 // indirect
 	github.com/oklog/run v1.2.0 // indirect
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
 	github.com/openbao/go-kms-wrapping/entropy/v2 v2.1.0 // indirect
@@ -253,6 +263,7 @@ require (
 	github.com/openbao/go-kms-wrapping/wrappers/transit/v2 v2.6.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
+	github.com/opencontainers/runc v1.2.3 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
 	github.com/oracle/oci-go-sdk/v60 v60.0.0 // indirect
 	github.com/ovh/kmip-go v0.3.3 // indirect
@@ -292,6 +303,9 @@ require (
 	github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c // indirect
 	github.com/vmware/govmomi v0.18.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,7 @@ github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBi
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KMJuWmfCkcxl09JwdlqwDZZ6U14=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -146,6 +147,8 @@ github.com/aliyun/alibaba-cloud-sdk-go v1.63.12 h1:O/lpYuNJlb5ed/QIJUDE1yJBh6zPF
 github.com/aliyun/alibaba-cloud-sdk-go v1.63.12/go.mod h1:SOSDHfe1kX91v3W5QiBsWSLqeLxImobbMX1mxrFHsVQ=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
+github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -213,6 +216,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bgentry/speakeasy v0.2.0 h1:tgObeVOf8WAvtuAX6DhJ4xks4CFNwPDZiqzGqIHE51E=
 github.com/bgentry/speakeasy v0.2.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -258,6 +262,8 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -645,6 +651,8 @@ github.com/jefferai/jsonx v1.0.1/go.mod h1:yFo3l2fcm7cZVHGq3HKLXE+Pd4RWuRjNBDHks
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
+github.com/jinzhu/copier v0.3.4 h1:mfU6jI9PtCeUjkjQ322dlff9ELjGDu975C2p/nrubVI=
+github.com/jinzhu/copier v0.3.4/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -667,6 +675,7 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
@@ -696,6 +705,8 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libdns/libdns v1.0.0 h1:IvYaz07JNz6jUQ4h/fv2R4sVnRnm77J/aOuC9B+TQTA=
 github.com/libdns/libdns v1.0.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/linode/linodego v0.7.1 h1:4WZmMpSA2NRwlPZcc0+4Gyn7rr99Evk9bnr0B3gXRKE=
@@ -805,6 +816,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2 h1:BQ1HW7hr4IVovMwWg0E0PYcyW8CzqDcVmaew9cujU4s=
 github.com/nicolai86/scaleway-sdk v1.10.2-0.20180628010248-798f60e20bb2/go.mod h1:TLb2Sg7HQcgGdloNxkrmtgDNR9uVYF3lfdFIN4Ro6Sk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
+github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -996,6 +1009,7 @@ github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
+github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.3 h1:7hth9376EoQEd1hH4lAp3vnaLP2UMyxuMMghLKzDHyU=
 github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.3/go.mod h1:Z5KcoM0YLC7INlNhEezeIZ0TZNYf7WSNO0Lvah4DSeQ=
 github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
@@ -1032,6 +1046,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c h1:u6SKchux2yDvFQnDHS3lPnIRmfVJ5Sxy3ao2SIdysLQ=
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
+github.com/typesense/typesense-go v1.1.0 h1:QocehDarVXRArMIosPIdawiVFZZbnRkPJxwnAGOFkzw=
+github.com/typesense/typesense-go v1.1.0/go.mod h1:KcPODU7ltrcUFC/gygMTkAAfZ9M8/q6ayrdl1MnE1kI=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
@@ -1042,6 +1058,7 @@ github.com/vmware/govmomi v0.18.0 h1:f7QxSmP7meCtoAmiKZogvVbLInT+CZx6Px6K5rYsJZo
 github.com/vmware/govmomi v0.18.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=


### PR DESCRIPTION
Hello! We needed a typesense plugin so we set this one up. We have been using it for a little bit so wanted to share it.

```
go build -o openbao-plugin-database-typesense ./database/typesense/cmd
SHA256=$(sha256sum openbao-plugin-database-typesense | cut -d' ' -f1)
# move plugin into folder
bao write sys/plugins/catalog/database/typesense-database-plugin \
    sha256="${SHA256}" \
    command="openbao-plugin-database-typesense"
```

After this we are able to use it
```
bao write labs/database/config/typesense-server \
    plugin_name="typesense-database-plugin" \
    allowed_roles="*" \
    api_url="https://typesense.example.com" \
    api_key="eee"

bao write labs/database/roles/dev-search-key \
    db_name="typesense-server" \
    creation_statements='{"actions": ["*"], "collections": ["*"]}' \
    default_ttl="1h" \
    max_ttl="24h"

bao read labs/database/creds/dev-search-key
```

UI for role works
<img width="1114" height="589" alt="image" src="https://github.com/user-attachments/assets/e0cfc25f-7552-4b71-938e-4a26c347145d" />
<img width="1114" height="589" alt="image" src="https://github.com/user-attachments/assets/4d7007d2-676c-4b68-a6ba-363022ddeca1" />

Not for the connection, but it is simple setup
<img width="1114" height="589" alt="image" src="https://github.com/user-attachments/assets/71ba8140-7f12-4791-a3a2-2e2bf675895b" />
