### PR TITLE
Bump toolchain to Go 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openbao/openbao-plugins
 
 go 1.25.0
 
+toolchain go1.26.4
+
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/kms v1.22.0


### PR DESCRIPTION
Releases were building with Go 1.25.0 which is rather dated.