### PR TITLE
feat: add session token to AWS backend

### DIFF
--- a/auth/aws/cli.go
+++ b/auth/aws/cli.go
@@ -41,7 +41,12 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	hlogger := hclog.Default()
 	hlogger.SetLevel(level)
 
-	creds, err := awsutil.RetrieveCreds(m["aws_access_key_id"], m["aws_secret_access_key"], m["aws_security_token"], hlogger)
+	awsSessionToken := m["aws_security_token"]
+	if m["aws_session_token"] != "" {
+		awsSessionToken = m["aws_session_token"]
+	}
+
+	creds, err := awsutil.RetrieveCreds(m["aws_access_key_id"], m["aws_secret_access_key"], awsSessionToken, hlogger)
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +116,10 @@ Configuration:
 
   aws_security_token=<string>
       Explicit AWS security token for temporary credentials
+			Deprecated: use aws_session_token instead
+
+  aws_session_token=<string>
+      Explicit AWS session token for temporary credentials
 
   header_value=<string>
       Value for the x-vault-aws-iam-server-id header in requests

--- a/secrets/aws/backend_test.go
+++ b/secrets/aws/backend_test.go
@@ -660,6 +660,9 @@ func testAccStepRead(t *testing.T, path, name string, credentialTests []credenti
 				SecretKey string `mapstructure:"secret_key"`
 				STSToken  string `mapstructure:"session_token"`
 			}
+			if resp.Data["security_token"] != resp.Data["session_token"] {
+				return fmt.Errorf("expect deprecated field 'security_token' to be equal to new 'session_token', but %v != %v", resp.Data["security_token"], resp.Data["session_token"])
+			}
 			if err := mapstructure.Decode(resp.Data, &d); err != nil {
 				return err
 			}

--- a/secrets/aws/backend_test.go
+++ b/secrets/aws/backend_test.go
@@ -658,7 +658,7 @@ func testAccStepRead(t *testing.T, path, name string, credentialTests []credenti
 			var d struct {
 				AccessKey string `mapstructure:"access_key"`
 				SecretKey string `mapstructure:"secret_key"`
-				STSToken  string `mapstructure:"security_token"`
+				STSToken  string `mapstructure:"session_token"`
 			}
 			if err := mapstructure.Decode(resp.Data, &d); err != nil {
 				return err

--- a/secrets/aws/secret_access_keys.go
+++ b/secrets/aws/secret_access_keys.go
@@ -45,6 +45,10 @@ func secretAccessKeys(b *backend) *framework.Secret {
 				Type:        framework.TypeString,
 				Description: "Security Token",
 			},
+			"session_token": {
+				Type:        framework.TypeString,
+				Description: "Session Token",
+			},
 		},
 
 		Renew:  b.secretAccessKeysRenew,
@@ -175,6 +179,7 @@ func (b *backend) getFederationToken(ctx context.Context, s logical.Storage,
 		"access_key":     *tokenResp.Credentials.AccessKeyId,
 		"secret_key":     *tokenResp.Credentials.SecretAccessKey,
 		"security_token": *tokenResp.Credentials.SessionToken,
+		"session_token":  *tokenResp.Credentials.SessionToken,
 		"ttl":            uint64(ttl.Seconds()),
 	}, map[string]interface{}{
 		"username": username,
@@ -273,6 +278,7 @@ func (b *backend) assumeRole(ctx context.Context, s logical.Storage,
 		"access_key":     *tokenResp.Credentials.AccessKeyId,
 		"secret_key":     *tokenResp.Credentials.SecretAccessKey,
 		"security_token": *tokenResp.Credentials.SessionToken,
+		"session_token":  *tokenResp.Credentials.SessionToken,
 		"arn":            *tokenResp.AssumedRoleUser.Arn,
 		"ttl":            uint64(ttl.Seconds()),
 	}, map[string]interface{}{
@@ -442,6 +448,7 @@ func (b *backend) secretAccessKeysCreate(
 		"access_key":     *keyResp.AccessKey.AccessKeyId,
 		"secret_key":     *keyResp.AccessKey.SecretAccessKey,
 		"security_token": nil,
+		"session_token":  nil,
 	}, map[string]interface{}{
 		"username": username,
 		"policy":   role,

--- a/secrets/aws/secret_access_keys.go
+++ b/secrets/aws/secret_access_keys.go
@@ -43,7 +43,9 @@ func secretAccessKeys(b *backend) *framework.Secret {
 			},
 			"security_token": {
 				Type:        framework.TypeString,
-				Description: "Security Token",
+				Description: "Security Token. Deprecated: use session_token instead",
+				Deprecated:  true,
+
 			},
 			"session_token": {
 				Type:        framework.TypeString,


### PR DESCRIPTION
<!--

Please make sure you read our contributing guide:

https://github.com/openbao/openbao/blob/development/CONTRIBUTING.md

-->

## Description

Adds `session-token` to the output of AWS backend role assumption, as it has surpassed the legacy `security-token`.
<!--

Describe in detail the changes you are proposing, and the rationale.

-->

## Rationale

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.

All Pull Requests must have an issue attached to them.

-->

Resolves: #112 

## Acknowledgements

 - [X] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [X] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.