### PR TITLE
Add Scaleway KMS plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/openbao/go-kms-wrapping/wrappers/ocikms/v2 v2.3.0
 	github.com/openbao/go-kms-wrapping/wrappers/ovhcloudkms/v2 v2.0.0
 	github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2 v2.6.0
+	github.com/openbao/go-kms-wrapping/wrappers/scalewaykms/v2 v2.0.0
 	github.com/openbao/go-kms-wrapping/wrappers/tcloudpublickms/v2 v2.0.0
 	github.com/openbao/openbao/api/v2 v2.5.1
 	github.com/openbao/openbao/sdk/v2 v2.5.1
@@ -201,6 +202,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sony/gobreaker v0.5.0 // indirect
 	github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -580,6 +580,8 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36 h1:ObX9hZmK+VmijreZO/8x9pQ8/P/ToHD/bdSb4Eg4tUo=
+github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36/go.mod h1:LEsDu4BubxK7/cWhtlQWfuxwL4rf/2UEpxXz1o1EMtM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shoenig/test v1.12.1 h1:mLHfnMv7gmhhP44WrvT+nKSxKkPDiNkIuHGdIGI9RLU=

--- a/kms/scaleway/cmd/main.go
+++ b/kms/scaleway/cmd/main.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 OpenBao a Series of LF Projects, LLC
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"github.com/openbao/go-kms-wrapping/plugin/v2"
+	"github.com/openbao/go-kms-wrapping/v2"
+	"github.com/openbao/go-kms-wrapping/wrappers/scalewaykms/v2"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		WrapperFactoryFunc: func() wrapping.Wrapper {
+			return scalewaykms.NewWrapper()
+		},
+	})
+}


### PR DESCRIPTION
### Description

Adds a seal plugin that serves the Scaleway Key Manager wrapper, allowing
OpenBao to auto-unseal using a Scaleway KMS key. This is the plugin counterpart
to the new `wrappers/scalewaykms` module in `go-kms-wrapping`.

`kms/scaleway/cmd/main.go` wires `scalewaykms.NewWrapper()` into `plugin.Serve`,
following the exact pattern of the existing `kms/aws` and `kms/ovhcloud` plugins.

## Rationale

Resolves: https://github.com/openbao/go-kms-wrapping/issues/118

### Dependency / ordering

> [!IMPORTANT]
> This PR depends on the Scaleway KMS wrapper being merged and released:
> **openbao/go-kms-wrapping#117**.
>
> `go.mod` currently requires
> `github.com/openbao/go-kms-wrapping/wrappers/scalewaykms/v2 v2.0.0`. Once the
> wrapper module is tagged, I will bump this to the released tag and run
> `go mod tidy` to populate `go.sum`. Happy to do that as soon as the tag exists.

### Testing

* `go build ./kms/scaleway/cmd` and `go vet ./kms/scaleway/...` pass locally
  (built against the wrapper module).
* KMS plugin tests are not run in this repository's CI matrix (per the
  `ci-test-matrix` target), consistent with the other KMS plugins.

### Validated end-to-end

This plugin binary was built (`CGO_ENABLED=0`), baked into an OpenBao 2.6.0
image, and registered as a declarative `plugin "kms" "scalewaykms"` +
`seal "scalewaykms"` on a Scaleway Kapsule cluster:

* OpenBao loads the external plugin (`Auto Seal: scalewaykms (builtin: false)`),
  verifies its `sha256sum`, and validates the key via `GetKey` at startup.
* `bao operator init` → auto-unseals (KMS Encrypt); pod restart → auto-unseals
  with the stored key (KMS Decrypt), no manual intervention.

## Acknowledgements

 - [x] By contributing this change, I certify I have not used generative AI
       (GitHub Copilot, Cursor, Claude Code, &c) in authoring these changes or
       filling out the pull request description or associated issue.
 - [x] By contributing this change, I certify I have signed-off on the
       [DCO ownership](https://developercertificate.org/) statement
       and this change did not use post-BUSL-licensed code from HashiCorp.
       Existing MPL-licensed code is still allowed, subject to attribution.
       Code authored by yourself and submitted to HashiCorp for inclusion is
       also allowed.