### PR TITLE
fix logicaltest does not call `Check` function of steps

### DIFF
--- a/internal/logicaltest/logicaltest.go
+++ b/internal/logicaltest/logicaltest.go
@@ -130,6 +130,17 @@ func Test(t *testing.T, c TestCase) {
 			t.Errorf("Response contained error at step %d: %s", i+1, resp.Error())
 			break
 		}
+
+		// Either the 'err' was nil or if an error was expected, it was set to nil.
+		// Call the 'Check' function if there is one.
+		//
+		// TODO: This works perfectly for now, but it would be better if 'Check'
+		// function takes in both the response object and the error, and decide on
+		// the action on its own.
+		if err == nil && s.Check != nil {
+			// Call the test method
+			err = s.Check(resp)
+		}
 	}
 
 	// Revoke any secrets we might have.


### PR DESCRIPTION
@satoqz I guess you planned to fix the 11 year old TODO and forgot.

I noticed because it breaks `TestAcceptanceBackend_basicSTS` of `secrets/aws`.
Probably because `Check` is used somewhere to update some variable based on the response, but I did not investigate. Maybe we should rename the function to `PostFlight` or `Process`, because I think doing this is a valid use case, but based on the comment:

```go
	// Check is called after this step is executed in order to test that the
	// step executed successfully. If not set, the next step will be called.
```

it is abuse of the callback.

For now I just restored the functionality (and comment)