### PR TITLE
Switch to new PKCS#11 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To learn more about OpenBao plugins, please see the
 - **Google Cloud KMS** - Auto Unseal via Google Cloud.
 - **OCI KMS** - Auto Unseal via Oracle Cloud.
 - **OVHcloud KMS** - Auto Unseal via OVHcloud.
-- **PKCS#11** - Auto Unseal via PKCS#11.
+- **PKCS#11** - Auto Unseal and External Keys via PKCS#11.
 - **T Cloud Public KMS** - Auto Unseal via T Cloud Public.
 
 ## Download

--- a/go.mod
+++ b/go.mod
@@ -54,15 +54,15 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/openbao/go-kms-wrapping/plugin/v2 v2.3.0
-	github.com/openbao/go-kms-wrapping/v2 v2.8.0
+	github.com/openbao/go-kms-wrapping/kms/pkcs11/v2 v2.0.0
+	github.com/openbao/go-kms-wrapping/plugin/v2 v2.4.0
+	github.com/openbao/go-kms-wrapping/v2 v2.9.0
 	github.com/openbao/go-kms-wrapping/wrappers/alicloudkms/v2 v2.3.0
 	github.com/openbao/go-kms-wrapping/wrappers/awskms/v2 v2.5.0
 	github.com/openbao/go-kms-wrapping/wrappers/azurekeyvault/v2 v2.4.0
 	github.com/openbao/go-kms-wrapping/wrappers/gcpckms/v2 v2.3.0
 	github.com/openbao/go-kms-wrapping/wrappers/ocikms/v2 v2.3.0
 	github.com/openbao/go-kms-wrapping/wrappers/ovhcloudkms/v2 v2.0.0
-	github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2 v2.6.0
 	github.com/openbao/go-kms-wrapping/wrappers/tcloudpublickms/v2 v2.0.0
 	github.com/openbao/openbao/api/v2 v2.6.0
 	github.com/openbao/openbao/sdk/v2 v2.6.2
@@ -173,7 +173,7 @@ require (
 	github.com/microsoft/kiota-serialization-multipart-go v1.0.0 // indirect
 	github.com/microsoft/kiota-serialization-text-go v1.0.0 // indirect
 	github.com/miekg/dns v1.1.63 // indirect
-	github.com/miekg/pkcs11 v1.1.2-0.20231115102856-9078ad6b9d4b // indirect
+	github.com/miekg/pkcs11 v1.1.2 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.2-0.20210821155943-2d9075ca8770 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -450,8 +450,8 @@ github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKju
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/dns v1.1.63 h1:8M5aAw6OMZfFXTT7K5V0Eu5YiiL8l7nUAkyN6C9YwaY=
 github.com/miekg/dns v1.1.63/go.mod h1:6NGHfjhpmr5lt3XPLuyfDJi5AXbNIPM9PY6H6sF1Nfs=
-github.com/miekg/pkcs11 v1.1.2-0.20231115102856-9078ad6b9d4b h1:J/AzCvg5z0Hn1rqZUJjpbzALUmkKX0Zwbc/i4fw7Sfk=
-github.com/miekg/pkcs11 v1.1.2-0.20231115102856-9078ad6b9d4b/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/miekg/pkcs11 v1.1.2 h1:/VxmeAX5qU6Q3EwafypogwWbYryHFmF2RpkJmw3m4MQ=
+github.com/miekg/pkcs11 v1.1.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
@@ -498,10 +498,12 @@ github.com/oapi-codegen/runtime v1.4.1 h1:9nwLoI+KrWxzbBcp0jO/R8uXqbik/HUyCvPeU6
 github.com/oapi-codegen/runtime v1.4.1/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
-github.com/openbao/go-kms-wrapping/plugin/v2 v2.3.0 h1:LxZHcCv8S3888OSAKs2n0rPurDstKiisAkr0U5s/qg8=
-github.com/openbao/go-kms-wrapping/plugin/v2 v2.3.0/go.mod h1:BSu5AczP5Y/8a/VDoBv/+aIooj09axNPVg/XYq9u2AQ=
-github.com/openbao/go-kms-wrapping/v2 v2.8.0 h1:9gXkCmcMadJO2Ozf9TNTIInSqdOwAD6k3HhHMhIqzrs=
-github.com/openbao/go-kms-wrapping/v2 v2.8.0/go.mod h1:KyL1nfZM8SzLgMchvFU2F5jS/XlauD3TRCjmILLErh4=
+github.com/openbao/go-kms-wrapping/kms/pkcs11/v2 v2.0.0 h1:nlCf8k2bFN263AzxvcdvKTtVaEJNJWXGFCcaPoFnZxc=
+github.com/openbao/go-kms-wrapping/kms/pkcs11/v2 v2.0.0/go.mod h1:Oe/Eebdt1ttMF3AYlVEPpFPMe1wB8ibMBME/hki/+eg=
+github.com/openbao/go-kms-wrapping/plugin/v2 v2.4.0 h1:ET70ooZHXwSCoEuNryKJfa2PvUZXAb3/l9o8dwWDYho=
+github.com/openbao/go-kms-wrapping/plugin/v2 v2.4.0/go.mod h1:EkWWwSq44YgaFY7OHPQtoiKEuSnKlk2K1muib3lIVro=
+github.com/openbao/go-kms-wrapping/v2 v2.9.0 h1:LI7DwOi1v4zv7FqBTbiChUzGo5kav9ONmwMYwnxNhFc=
+github.com/openbao/go-kms-wrapping/v2 v2.9.0/go.mod h1:CcqEQD8O2fsOG40hlT/oR5RTkus0zvjfsnCrFkRNf48=
 github.com/openbao/go-kms-wrapping/wrappers/alicloudkms/v2 v2.3.0 h1:RhTCVY+QnUNP/URMKz4kWYHt+6ppAYEC1LbOgt8l8d0=
 github.com/openbao/go-kms-wrapping/wrappers/alicloudkms/v2 v2.3.0/go.mod h1:3GLoNvJvwsFgr3rnohIVfE9GbpICJVvSACO/z/B1IgE=
 github.com/openbao/go-kms-wrapping/wrappers/awskms/v2 v2.5.0 h1:Ez91i4H9PeuCJ9ASkWbt0sUItEkEVRkM7v97D5YaiEA=
@@ -514,8 +516,6 @@ github.com/openbao/go-kms-wrapping/wrappers/ocikms/v2 v2.3.0 h1:91C1/ex/BIP5qbTN
 github.com/openbao/go-kms-wrapping/wrappers/ocikms/v2 v2.3.0/go.mod h1:OsP3JqWnM4fXiV8rhDr2c64eBGbN6U54nAkBNcoxejw=
 github.com/openbao/go-kms-wrapping/wrappers/ovhcloudkms/v2 v2.0.0 h1:cx8e45QIr4VFTrnxuo4isqUjoN5MhH3YjadWEtqvv18=
 github.com/openbao/go-kms-wrapping/wrappers/ovhcloudkms/v2 v2.0.0/go.mod h1:A2oFUe1pm44eVzqI1GEcGvDZ+8H/WbBFiNEqfKwVp2I=
-github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2 v2.6.0 h1:N1wn2f6CJ5kb39csWK9Yt6YedLK2wM7aGR168WQHeLo=
-github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2 v2.6.0/go.mod h1:xPvAJyNNaeMzEW+FBq+r/Uv3PgQLEAhkVGOXrD8t79E=
 github.com/openbao/go-kms-wrapping/wrappers/tcloudpublickms/v2 v2.0.0 h1:YVh2auXJQqnZc/Oe1sUppD0JhxVDGRLAMx1JttDTTk8=
 github.com/openbao/go-kms-wrapping/wrappers/tcloudpublickms/v2 v2.0.0/go.mod h1:8HKyId6HFJiOekGBltanliJPlXc4CrhCO+uYafgziPU=
 github.com/openbao/openbao/api/v2 v2.6.0 h1:KvfspAaL9bab9hI8jFYkV2cgtSrwWtaG+k9AUTHWU4M=

--- a/kms/pkcs11/cmd/main.go
+++ b/kms/pkcs11/cmd/main.go
@@ -4,15 +4,48 @@
 package main
 
 import (
+	"errors"
+	"flag"
+	"strings"
+
+	"github.com/openbao/go-kms-wrapping/kms/pkcs11/v2"
 	"github.com/openbao/go-kms-wrapping/plugin/v2"
-	"github.com/openbao/go-kms-wrapping/v2"
-	"github.com/openbao/go-kms-wrapping/wrappers/pkcs11/v2"
+	wrapping "github.com/openbao/go-kms-wrapping/v2"
+	"github.com/openbao/go-kms-wrapping/v2/kms"
 )
 
 func main() {
+	aliases := make(map[string]string)
+
+	flag.Func(
+		"alias",
+		"Register a PKCS#11 library path alias. This option is repeatable.",
+		func(s string) error {
+			parts := strings.SplitN(s, "=", 2)
+			if len(parts) != 2 {
+				return errors.New(`aliases are passed as "<name>=<path>"`)
+			}
+			aliases[parts[0]] = parts[1]
+			return nil
+		},
+	)
+
+	flag.Parse()
+
+	opts := []pkcs11.Option{
+		pkcs11.WithAliasesFromEnv(),
+		pkcs11.WithAliases(aliases),
+	}
+
 	plugin.Serve(&plugin.ServeOpts{
+		KMSFactoryFunc: func() kms.KMS {
+			return pkcs11.New(opts...)
+		},
 		WrapperFactoryFunc: func() wrapping.Wrapper {
-			return pkcs11.NewWrapper()
+			return pkcs11.NewWrapper(opts...)
+		},
+		Metadata: plugin.Metadata{
+			SensitiveKMSFields: pkcs11.SensitiveKMSFields,
 		},
 	})
 }


### PR DESCRIPTION
Config then looks like:

```hcl
plugin "kms" "pkcs11" {
  command = "openbao-plugin-kms-pkcs11"
  args    = ["-alias=softhsm=/opt/homebrew/lib/softhsm/libsofthsm2.so"]
}
```

or, via env:

```hcl
plugin "kms" "pkcs11" {
  command = "openbao-plugin-kms-pkcs11"
  env     = ["BAO_PKCS11_ALIASES=softhsm=/opt/homebrew/lib/softhsm/libsofthsm2.so"]
}
```

(or, set `BAO_PKCS11_ALIASES` within the environment of the main process directly)

And in external keys land:

```console
$ bao write sys/external-keys/configs/foo plugin=pkcs11 lib=/my/bad/library/path.so token_label=openbao pin=1234
Error writing data to sys/external-keys/configs/foo: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/sys/external-keys/configs/foo
Code: 400. Errors:

* unknown library alias: "/my/bad/library/path.so"

$ bao write sys/external-keys/configs/foo plugin=pkcs11 lib=softhsm token_label=openbao pin=1234
Success! Data written to: sys/external-keys/configs/foo
```

Also see: https://github.com/openbao/openbao/issues/3338